### PR TITLE
Main

### DIFF
--- a/test.jtoy
+++ b/test.jtoy
@@ -10,11 +10,26 @@ REPEATING :: 0x1;
 //file := cast (*Compiler_Message_File) message;
 #import "test2.jtoy";
 
+Namespace :: struct
+{
+    cVec :: 2;  
+};
+
 Vector2 :: struct
 {
     x : float = 1;
     y : float = 2;
 };
+
+Sprite :: struct
+{
+    aVec : [Namespace.cVec] Vector2;
+    g := 4.3;
+    zip : s64 = 98052;
+};
+
+vec : Vector2;
+gPi := 3.14159;
 
 printf :: (format : * char, ..) -> int #foreign;
 
@@ -22,17 +37,46 @@ Factorial :: (n : s64) -> s64 { if n == 0 return 1; return n * Factorial(n-1); }
 
 main :: ()
 {
-	i := 0; // BB (adrianb) What's the right type for this? s64?
+    i := 0; // BB (adrianb) What's the right type for this? s64?
     c := CLoop();
     a :: 2;
     b := 900;
 
+    aVec : [2] Vector2;
+    aSprite : [2] Sprite;
+
+    aSprite[1].zip = 98004;
+    aSprite[0].aVec[1].y = 30.4;
+
+    aG : [3] float;
+
+    aG[2] = 5.5;
+
+    aVec[1].x = 9003;
+    aVec[0].y = 46;
+
     pB := *b;
     << pB = 400;
 
+    vec2 : Vector2;
+    vec2.x = 50;
+    vec2.y = 313;
+
+    printf("vec = (%f, %f)\n", vec.x, vec.y);
+    printf("vec2 = (%f, %f)\n", vec2.x, vec2.y);
+    printf("aVec = [(%f, %f), (%f, %f)]\n", aVec[0].x, aVec[0].y, aVec[1].x, aVec[1].y);
+    printf("aSprite = [([(%f, %f), (%f, %f)], %f, %lld), ([(%f, %f), (%f, %f)], %f, %lld)]\n", 
+           aSprite[0].aVec[0].x, aSprite[0].aVec[0].y, aSprite[0].aVec[1].x, aSprite[0].aVec[1].y, aSprite[0].g, aSprite[0].zip,
+           aSprite[1].aVec[0].x, aSprite[1].aVec[0].y, aSprite[1].aVec[1].x, aSprite[1].aVec[1].y, aSprite[1].g, aSprite[1].zip);
+    printf("aG = [%f, %f, %f]\n", aG[0], aG[1], aG[2]);
+    printf("pi = %f\n", gPi);
+    gPi = 3;
+    printf("bad pi = %f\n", gPi);
+    printf("a = %d %d %d\n", a, a, a);
+
     // BB (adrianb) Should error on i < c because types don't match...
 
-	while i < c
+    while i < c
     {
         printf("\"i\" = %d\n", a + << pB + -i);
         ++i;

--- a/test_in_c.cpp
+++ b/test_in_c.cpp
@@ -1,0 +1,72 @@
+//map :: (array: [] $T, f: (T) -> $R) -> [] R {
+//}
+
+//array_unordered_remove :: inline (array: *[..] $T, item: T) -> s64 {
+//    return 0;
+//}
+
+static const int REPEATING = 0x1;
+
+struct Vector2
+{
+    float x; // : float = 1;
+    float y; // : float = 2;
+};
+
+Vector2 vec = { 1, 2 };
+float gPi = 3.14159f;
+
+int printf(const char *, ...);
+
+long long Factorial(long long n)
+{
+    if (n == 0)
+        return 1; 
+
+    return n * Factorial(n-1); 
+}
+
+int main ()
+{
+	signed char i = 0; // BB (adrianb) What's the right type for this? s64?
+    long long c = 5;
+    static const signed char a = 2;
+    short b = 900;
+    Vector2 aVec[] = { {1, 2}, {1, 2} };
+    float aG[3] = {};
+
+    aG[2] = 5.5;
+
+    aVec[1].x = 9003;
+    aVec[0].y = 46;
+
+    short * pB = &b;
+    *pB = 400;
+
+    Vector2 vec2 = {};
+    vec2.x = 50;
+    vec2.y = 313;
+
+    printf("vec = (%f, %f)\n", vec.x, vec.y);
+    printf("vec2 = (%f, %f)\n", vec2.x, vec2.y);
+    printf("aVec = [(%f, %f), (%f, %f)]\n", aVec[0].x, aVec[0].y, aVec[1].x, aVec[1].y);
+    printf("aG = [%f, %f, %f]\n", aG[0], aG[1], aG[2]);
+    
+
+    printf("pi = %f\n", gPi);
+    gPi = 3;
+    printf("bad pi = %f\n", gPi);
+    printf("a = %d %d %d\n", a, a, a);
+
+    // BB (adrianb) Should error on i < c because types don't match...
+
+	while (i < c)
+    {
+        printf("\"i\" = %d\n", a + *pB + -i);
+        ++i;
+    }
+
+    printf("factorial(%lld) == %lld\n", 5ll, Factorial(5ll));
+
+    return 0;
+}


### PR DESCRIPTION
- Raised priority of dot operator (wasn’t working with multiple array
  indirection).
- Fixed C-vararg rules (convert to double/int).
- Added a limited constant generation path so array type can have a
  literal size rather than point into the AST.
- More type casting supported (in both paths).
- Global variables are initialized correctly.
- Default value initialization setup (need for structs). Currently
  structs/arrays generate to assignment where clang generates a memcpy
  from constant data. May need to change.
- Add test_in_c.cpp to compare with IR generated from clang.
