### PR TITLE
Main

### DIFF
--- a/test.jtoy
+++ b/test.jtoy
@@ -56,6 +56,7 @@ main :: ()
     aVec[0].y = 46;
 
     pB := *b;
+    defer { printf("Leaving and pB = %d\n", << pB); }
     << pB = 400;
 
     vec2 : Vector2;
@@ -81,6 +82,16 @@ main :: ()
         printf("\"i\" = %d\n", a + << pB + -i);
         ++i;
     }
+
+    fEarly := true; //false;
+    if (fEarly)
+    {
+        return;
+    }
+
+    printf("Made it past early\n");
+
+    b = 302;
 
     printf("factorial(%ld) == %ld\n", CLoop(), Factorial(CLoop()));
 }

--- a/test.jtoy
+++ b/test.jtoy
@@ -17,6 +17,7 @@ Namespace :: struct
 
 Vector2 :: struct
 {
+    dim :: 2;
     x : float = 1;
     y : float = 2;
 };
@@ -24,6 +25,7 @@ Vector2 :: struct
 Sprite :: struct
 {
     aVec : [Namespace.cVec] Vector2;
+    using pos : Vector2;
     g := 4.3;
     zip : s64 = 98052;
 };
@@ -45,6 +47,8 @@ main :: ()
     aVec : [2] Vector2;
     aSprite : [2] Sprite;
 
+    aSprite[1].x = 5.5;
+    aSprite[1].y = 10.5;
     aSprite[1].zip = 98004;
     aSprite[0].aVec[1].y = 30.4;
 
@@ -63,25 +67,35 @@ main :: ()
     vec2.x = 50;
     vec2.y = 313;
 
-    printf("vec = (%f, %f)\n", vec.x, vec.y);
+    printf("vec = (%f, %f) dim %d\n", vec.x, vec.y, vec.dim);
     printf("vec2 = (%f, %f)\n", vec2.x, vec2.y);
     printf("aVec = [(%f, %f), (%f, %f)]\n", aVec[0].x, aVec[0].y, aVec[1].x, aVec[1].y);
-    printf("aSprite = [([(%f, %f), (%f, %f)], %f, %lld), ([(%f, %f), (%f, %f)], %f, %lld)]\n", 
-           aSprite[0].aVec[0].x, aSprite[0].aVec[0].y, aSprite[0].aVec[1].x, aSprite[0].aVec[1].y, aSprite[0].g, aSprite[0].zip,
-           aSprite[1].aVec[0].x, aSprite[1].aVec[0].y, aSprite[1].aVec[1].x, aSprite[1].aVec[1].y, aSprite[1].g, aSprite[1].zip);
+    printf("aSprite = [([(%f, %f), (%f, %f)], (%f, %f), %f, %lld), ([(%f, %f), (%f, %f)], (%f, %f), %f, %lld)]\n", 
+           aSprite[0].aVec[0].x, aSprite[0].aVec[0].y, aSprite[0].aVec[1].x, aSprite[0].aVec[1].y, aSprite[0].x, 
+                aSprite[0].y, aSprite[0].g, aSprite[0].zip,
+           aSprite[1].aVec[0].x, aSprite[1].aVec[0].y, aSprite[1].aVec[1].x, aSprite[1].aVec[1].y, aSprite[1].x, 
+                aSprite[1].y, aSprite[1].g, aSprite[1].zip);
     printf("aG = [%f, %f, %f]\n", aG[0], aG[1], aG[2]);
     printf("pi = %f\n", gPi);
     gPi = 3;
     printf("bad pi = %f\n", gPi);
     printf("a = %d %d %d\n", a, a, a);
 
-    // BB (adrianb) Should error on i < c because types don't match...
+    using pos : Vector2;
+    x = 50.5;
+    y = 323.23;
+
+    printf("pos local is %f, %f\n", x, y);
+
+    // BB (adrianb) Should error on i < c because types don't match...?
 
     while i < c
     {
         printf("\"i\" = %d\n", a + << pB + -i);
         ++i;
     }
+
+    printf("factorial(%ld) == %ld\n", CLoop(), Factorial(CLoop()));
 
     fEarly := true; //false;
     if (fEarly)
@@ -92,6 +106,4 @@ main :: ()
     printf("Made it past early\n");
 
     b = 302;
-
-    printf("factorial(%ld) == %ld\n", CLoop(), Factorial(CLoop()));
 }


### PR DESCRIPTION
I would like it to work for types, but unordered resolution produces
cycles. There are ways around it, but I’m unsure which would be least
confusing as a user visible rule (e.g. all “using Type;” run before
“using decl :…” and declarations in a struct can’t look through the 2nd
set of using info). Potentially confusing :/.
